### PR TITLE
Fix NaN avgRatings from display

### DIFF
--- a/lib/components/menuItemListTile.dart
+++ b/lib/components/menuItemListTile.dart
@@ -30,7 +30,7 @@ class _MenuItemListTile extends State<MenuItemListTile> {
   void getAvgRating() async {
     var res = await _fsm.getDocData(
         _fsm.menuItemCollection, widget.menuItem.id, "avgRating");
-    if (res == null) {
+    if (res == null || res == double.nan) {
       res = 0;
     }
     if (mounted) setState(() {
@@ -98,7 +98,10 @@ class _MenuItemListTile extends State<MenuItemListTile> {
                           String streamAvgRating = "0";
                           try 
                           {
-                            streamAvgRating = snapshot.data['avgRating'].toString();
+                            streamAvgRating = snapshot.data['avgRating'].toStringAsFixed(1);
+                            if(streamAvgRating == "NaN") {
+                              streamAvgRating = "0";
+                            }
                           } 
                           catch (e) 
                           {


### PR DESCRIPTION
This is a frontend fix for any NaN avg ratings that get left in the database.

I checked aggregateRatings in index.js, we aren't dividing by zero anywhere (unless things elsewhere get really fucked up). I tried to recreate any strange cases that might cause a NaN to appear when leaving a rating, but I couldn't replicate the issue. The NaN's were likely just leftover from a when code was half finished or not working, but now that it is its no longer an issue. Either way, this fix will prevent any NaNs from displaying if they do somehow end up in the database again.

I also went through our database and deleted any menuItem documents that had NaN as their average rating, so none should show up now regardless.