### PR TITLE
Mostpopular mocumenu bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,18 @@
-# bitewise
+![unnamed](https://user-images.githubusercontent.com/50386308/113807881-e15c1780-9732-11eb-92f7-65ce1508fdeb.png)
 
-Coming soon
 
-## Getting Started
+# About
 
-This project is a starting point for a Flutter application.
+Bitewise is a cross-platform mobile application which allows users to rate and discover menu items at restaurants near them. The goal of this project is to develop an application that improves the restaurant dining experience by focusing on individual menu items rather than restaurants as a whole.
 
-A few resources to get you started if this is your first Flutter project:
+&nbsp;
+&nbsp;
+&nbsp;
 
-- [Lab: Write your first Flutter app](https://flutter.dev/docs/get-started/codelab)
-- [Cookbook: Useful Flutter samples](https://flutter.dev/docs/cookbook)
+![image](https://user-images.githubusercontent.com/50386308/113807335-ecfb0e80-9731-11eb-8eb8-d16acf5dd977.png)
+![image](https://user-images.githubusercontent.com/50386308/113807345-f4bab300-9731-11eb-92d6-e29b0d42ceb6.png)
 
-For help getting started with Flutter, view our
-[online documentation](https://flutter.dev/docs), which offers tutorials,
-samples, guidance on mobile development, and a full API reference.
+
+## Technologies Used
+- Flutter
+- Firebase


### PR DESCRIPTION
Assume Item A exists ONLY in Documenu

- Firebase has Restaurant X rated items as []
- User using Documenu rates A
- Firebase has Restaurant X rated items as [A]
- User using Mocumenu tries to load Restaurant X
- App crashes because A doesn't exist in Mocumenu

This skips trying to build any popular item that isn't available from the current data provider.

The only changed file here is actually `lib/util/menuUtil.dart`. Not sure why the others are showing changes.
