### PR TITLE
Update prev rated items

### DIFF
--- a/lib/pages/prevRatedItemsPage.dart
+++ b/lib/pages/prevRatedItemsPage.dart
@@ -313,14 +313,15 @@ class _PrevRatedItemsPageState extends State<PrevRatedItemsPage> {
                             mainAxisAlignment: MainAxisAlignment.center,
                             children: [
                               FlatButton(
-                                onPressed: () => {
-                                  Navigator.push(
-                                      context,
-                                      MaterialPageRoute(
-                                          builder: (context) => RestaurantPage(
-                                              restaurant:
-                                                  displayRestaurants[index-1],
-                                              itemId: displayItems[index-1].id)))
+                                onPressed: () async {
+                                  String s = await Navigator.push(
+                                    context,
+                                    MaterialPageRoute(
+                                        builder: (context) => RestaurantPage(
+                                            restaurant:
+                                                displayRestaurants[index - 1],
+                                            itemId: displayItems[index - 1].id)));
+                                  getPrevRatedItems();
                                 },
                                 child: PrevRatedItemTile(
                                     displayItems[index-1], displayRatings[index-1],

--- a/lib/pages/restaurantPage.dart
+++ b/lib/pages/restaurantPage.dart
@@ -511,7 +511,7 @@ class _RestaurantPageState extends State<RestaurantPage> {
               leading: GestureDetector(
                 child: Icon(Icons.chevron_left, size: 35, color: Colors.black),
                 onTap: () {
-                  Navigator.pop(context);
+                  Navigator.pop(context, "returnFromRestaurantPage");
                 }
               ),
               actions: <Widget>[


### PR DESCRIPTION
This change reloads the list of previously rated items upon returning from the restaurant page, that way if someone updates a previous rating, it gets reflected when they return.